### PR TITLE
Update README to show correct user in process list

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ process tree:
 # normal process tree
 $ ssh foo@bar
 $ ps -ef --forest
-root         931     765  1 18:04 ?        00:00:00  \_ sshd: root@pts/1
-root         938     931  0 18:04 pts/1    00:00:00      \_ -bash
+root         931     765  1 18:04 ?        00:00:00  \_ sshd: foo@pts/1
+foo          938     931  0 18:04 pts/1    00:00:00      \_ -bash
 
 # backdoor process tree
 $ xzbot -cmd 'sleep 30'

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ process tree:
 # normal process tree
 $ ssh foo@bar
 $ ps -ef --forest
-foo         931     765  1 18:04 ?        00:00:00  \_ sshd: foo@pts/1
+foo          931     765  1 18:04 ?        00:00:00  \_ sshd: foo@pts/1
 foo          938     931  0 18:04 pts/1    00:00:00      \_ -bash
 
 # backdoor process tree

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ process tree:
 # normal process tree
 $ ssh foo@bar
 $ ps -ef --forest
-root         931     765  1 18:04 ?        00:00:00  \_ sshd: foo@pts/1
+foo         931     765  1 18:04 ?        00:00:00  \_ sshd: foo@pts/1
 foo          938     931  0 18:04 pts/1    00:00:00      \_ -bash
 
 # backdoor process tree


### PR DESCRIPTION
Conventionally when sshd is run as root and a user connects to that host with `foo@host`, the process list would show user `foo` for the opened pty and shell, rather than root.